### PR TITLE
Added URI match depth

### DIFF
--- a/src/mavigator.js
+++ b/src/mavigator.js
@@ -13,6 +13,7 @@ class Mavigator {
             className: 'active',
             classToParent: false,
             uri: window.location.pathname,
+            depth: false,
             warn: false
         };
     }
@@ -78,7 +79,16 @@ class Mavigator {
         let links = set.querySelectorAll(selector);
         links = [].slice.call(links);
 
-        return links.filter(link => link.pathname === this.options.uri);
+        return links.filter(function (link) {
+            if(_this.options.depth) {
+                var uri = _this.options.uri.slice(1).split('/');
+                uri.splice(_this.options.depth);
+
+                return link.pathname === '/' + uri.join('/');
+            }
+
+            return link.pathname === _this.options.uri;
+        });
     }
 
     addClassTo(node) {


### PR DESCRIPTION
Allows control over uri slug depth check, useful for side-by-side column navigation where a primary navigation has single depth URI link while viewing a child page of a sub menu.

**/settings/users**

```javascript
    Mavigator.mark('aside.main', {
        depth: 1
    });

    Mavigator.mark('aside.sub');
```
```html
    <aside class="main">
        <nav role="navigation">
            <div class="navbar-header">
                <a role="menuitem" href="/" title="Dashboard"><span class="glyphicons glyphicons-show-thumbnails"></span></a>
            </div>

            <div class="nav navbar-nav admin-nav">
                <a role="menuitem" href="/settings" title="System Settings" class="active"><span class="glyphicons glyphicons-settings"></span></a>
            </div>
        </nav>
    </aside>

    <aside class="sub">
        <nav>
            <h6>GENERAL</h6>
            <a href="/settings/users" class="active">Users</a>
            <a href="/settings/access">Access Keys</a>
        </nav>
    </aside>
```